### PR TITLE
Support review remediation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.jahia.community</groupId>
     <artifactId>support-token-authentication-valve</artifactId>
     <name>Support Token Authentication Valve</name>
-    <version>3.0.2-SNAPSHOT</version>
+    <version>3.1.0-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <description>Jahia module that manages temporary support tokens for user authentication.</description>
 

--- a/src/main/java/org/jahia/community/token/SupportTokenConstants.java
+++ b/src/main/java/org/jahia/community/token/SupportTokenConstants.java
@@ -11,6 +11,13 @@ public final class SupportTokenConstants {
     public static final String PROP_RECIPIENT = "recipient";
     public static final String PROP_TOKEN = "token";
 
+    /**
+     * HTTP session attribute set when the current session was established via a support token.
+     * Callers that must not serve token-authenticated sessions (e.g. token-management GraphQL
+     * operations) check for the presence of this attribute.
+     */
+    public static final String SESSION_SUPPORT_TOKEN_AUTH = "supportTokenAuth";
+
     private SupportTokenConstants() {
     }
 

--- a/src/main/java/org/jahia/community/token/SupportTokenUtils.java
+++ b/src/main/java/org/jahia/community/token/SupportTokenUtils.java
@@ -3,7 +3,6 @@ package org.jahia.community.token;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
-import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
 import javax.jcr.RepositoryException;
@@ -50,8 +49,8 @@ public final class SupportTokenUtils {
             final JCRUserNode jahiaUser = userManagerService.lookupUser(username, siteKey, session);
             if (jahiaUser != null && jahiaUser.hasNode(SupportTokenConstants.NODE_NAME_TOKEN_HISTORY)) {
                 final JCRNodeIteratorWrapper nodeIteratorWrapper = jahiaUser.getNode(SupportTokenConstants.NODE_NAME_TOKEN_HISTORY).getNodes();
-                for (Iterator<JCRNodeWrapper> iterator = nodeIteratorWrapper.iterator(); nodeIteratorWrapper.hasNext();) {
-                    final JCRNodeWrapper node = iterator.next();
+                while (nodeIteratorWrapper.hasNext()) {
+                    final JCRNodeWrapper node = (JCRNodeWrapper) nodeIteratorWrapper.next();
                     final String description = node.getPropertyAsString(SupportTokenConstants.PROP_DESCRIPTION);
                     final String expiration = node.getPropertyAsString(SupportTokenConstants.PROP_EXPIRATION);
                     final String recipient = node.getPropertyAsString(SupportTokenConstants.PROP_RECIPIENT);
@@ -65,7 +64,6 @@ public final class SupportTokenUtils {
     }
 
     public static boolean addToken(String username, String siteKey, String recipient, String description, Long expiration, String token, JahiaUserManagerService userManagerService) throws RepositoryException {
-        LOGGER.info("Updating user");
         return JCRTemplate.getInstance().doExecuteWithSystemSession((JCRSessionWrapper session) -> {
             final JCRUserNode jahiaUser = userManagerService.lookupUser(username, siteKey, session);
             if (jahiaUser != null) {
@@ -78,7 +76,9 @@ public final class SupportTokenUtils {
                 }
                 final SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd-HH-mm-ss");
                 final Date tokenDate = new Date();
-                final String nodeName = dateFormat.format(tokenDate);
+                // Append a short random suffix so two tokens created in the same second
+                // produce distinct node names and don't collide.
+                final String nodeName = dateFormat.format(tokenDate) + "-" + UUID.randomUUID().toString().substring(0, 8);
                 final JCRNodeWrapper tokenNode = tokenHistory.addNode(nodeName, SupportTokenConstants.NODE_TYPE_TOKEN);
                 tokenNode.setProperty(SupportTokenConstants.PROP_TOKEN, PasswordService.getInstance().digest(token));
                 tokenNode.setProperty(SupportTokenConstants.PROP_EXPIRATION, expiration);
@@ -124,7 +124,7 @@ public final class SupportTokenUtils {
                                 + "Regards,";
 
                         mailService.sendMessage(sender, mailService.defaultRecipient(), null, null, subject,
-                                String.format(body, userKey, tokenDate, description, expiration, DateFormatUtils.ISO_DATETIME_TIME_ZONE_FORMAT.format(tokenDate.getTime() + expiration)));
+                                String.format(body, userKey, tokenDate, description, expiration, DateFormatUtils.ISO_DATETIME_TIME_ZONE_FORMAT.format(tokenDate.getTime() + expiration * 60_000L)));
                     }
                 } catch (RepositoryException ex) {
                     LOGGER.error("Cannot save user properties", ex);

--- a/src/main/java/org/jahia/community/token/command/ListCommand.java
+++ b/src/main/java/org/jahia/community/token/command/ListCommand.java
@@ -29,7 +29,7 @@ public class ListCommand implements Action {
     public Object execute() throws RepositoryException {
         final List<String> userTokens = new ArrayList<>();
         if (StringUtils.isBlank(username)) {
-            LOGGER.warn("Impossible to clear the tokens, the username is empty");
+            LOGGER.warn("Impossible to list the tokens, the username is empty");
         } else {
             userTokens.addAll(SupportTokenUtils.listUserTokens(username, siteKey, JahiaUserManagerService.getInstance()));
         }

--- a/src/main/java/org/jahia/community/token/graphql/SupportTokenMutationExtension.java
+++ b/src/main/java/org/jahia/community/token/graphql/SupportTokenMutationExtension.java
@@ -4,14 +4,19 @@ import graphql.annotations.annotationTypes.GraphQLDescription;
 import graphql.annotations.annotationTypes.GraphQLField;
 import graphql.annotations.annotationTypes.GraphQLName;
 import graphql.annotations.annotationTypes.GraphQLTypeExtension;
+import graphql.schema.DataFetchingEnvironment;
 import org.jahia.modules.graphql.provider.dxm.DXGraphQLProvider;
 import org.jahia.modules.graphql.provider.dxm.security.GraphQLRequiresPermission;
+import org.jahia.modules.graphql.provider.dxm.util.ContextUtil;
+import org.jahia.community.token.SupportTokenConstants;
 import org.jahia.community.token.SupportTokenUtils;
 import org.jahia.services.usermanager.JahiaUserManagerService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.jcr.RepositoryException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
 
 @GraphQLTypeExtension(DXGraphQLProvider.Mutation.class)
 @GraphQLName("SupportTokenMutations")
@@ -32,8 +37,13 @@ public class SupportTokenMutationExtension {
             @GraphQLName("siteKey") @GraphQLDescription("Site key (null for global users)") String siteKey,
             @GraphQLName("recipient") @GraphQLDescription("Email address that will receive the token") String recipient,
             @GraphQLName("description") @GraphQLDescription("Purpose of this token") String description,
-            @GraphQLName("expiration") @GraphQLDescription("Expiration in minutes (default: 60)") Long expiration) {
+            @GraphQLName("expiration") @GraphQLDescription("Expiration in minutes (default: 60)") Long expiration,
+            DataFetchingEnvironment environment) {
 
+        if (isTokenAuthenticatedSession(environment)) {
+            LOGGER.warn("supportTokenCreate: refused — caller is authenticated via a support token");
+            return null;
+        }
         if (username == null || username.isEmpty() || recipient == null || recipient.isEmpty()) {
             LOGGER.warn("supportTokenCreate: username and recipient are required");
             return null;
@@ -61,8 +71,13 @@ public class SupportTokenMutationExtension {
     @GraphQLRequiresPermission("admin")
     public static Boolean clearAllTokens(
             @GraphQLName("username") @GraphQLDescription("Username whose tokens should be cleared") String username,
-            @GraphQLName("siteKey") @GraphQLDescription("Site key (null for global users)") String siteKey) {
+            @GraphQLName("siteKey") @GraphQLDescription("Site key (null for global users)") String siteKey,
+            DataFetchingEnvironment environment) {
 
+        if (isTokenAuthenticatedSession(environment)) {
+            LOGGER.warn("supportTokenClearAll: refused — caller is authenticated via a support token");
+            return Boolean.FALSE;
+        }
         if (username == null || username.isEmpty()) {
             return Boolean.FALSE;
         }
@@ -72,5 +87,19 @@ public class SupportTokenMutationExtension {
             LOGGER.error("Failed to clear tokens for user: {}", username, e);
             return Boolean.FALSE;
         }
+    }
+
+    /**
+     * Returns {@code true} when the caller's HTTP session was established by the support-token
+     * auth valve.  Token-authenticated sessions must not be allowed to mint or clear tokens
+     * (privilege escalation / persistence prevention).
+     */
+    private static boolean isTokenAuthenticatedSession(DataFetchingEnvironment environment) {
+        final HttpServletRequest request = ContextUtil.getHttpServletRequest(environment.getContext());
+        if (request == null) {
+            return false;
+        }
+        final HttpSession session = request.getSession(false);
+        return session != null && Boolean.TRUE.equals(session.getAttribute(SupportTokenConstants.SESSION_SUPPORT_TOKEN_AUTH));
     }
 }

--- a/src/main/java/org/jahia/community/token/graphql/SupportTokenQueryExtension.java
+++ b/src/main/java/org/jahia/community/token/graphql/SupportTokenQueryExtension.java
@@ -4,9 +4,11 @@ import graphql.annotations.annotationTypes.GraphQLDescription;
 import graphql.annotations.annotationTypes.GraphQLField;
 import graphql.annotations.annotationTypes.GraphQLName;
 import graphql.annotations.annotationTypes.GraphQLTypeExtension;
+import graphql.schema.DataFetchingEnvironment;
 import org.jahia.api.Constants;
 import org.jahia.modules.graphql.provider.dxm.DXGraphQLProvider;
 import org.jahia.modules.graphql.provider.dxm.security.GraphQLRequiresPermission;
+import org.jahia.modules.graphql.provider.dxm.util.ContextUtil;
 import org.jahia.community.token.SupportTokenConstants;
 import org.jahia.services.content.JCRNodeIteratorWrapper;
 import org.jahia.services.content.JCRNodeWrapper;
@@ -17,9 +19,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.jcr.RepositoryException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 
 @GraphQLTypeExtension(DXGraphQLProvider.Query.class)
@@ -38,8 +41,13 @@ public class SupportTokenQueryExtension {
     @GraphQLRequiresPermission("admin")
     public static List<GqlSupportTokenInfo> listTokens(
             @GraphQLName("username") @GraphQLDescription("Username to query") String username,
-            @GraphQLName("siteKey") @GraphQLDescription("Site key (null for global users)") String siteKey) {
+            @GraphQLName("siteKey") @GraphQLDescription("Site key (null for global users)") String siteKey,
+            DataFetchingEnvironment environment) {
 
+        if (isTokenAuthenticatedSession(environment)) {
+            LOGGER.warn("supportTokenListTokens: refused — caller is authenticated via a support token");
+            return Collections.emptyList();
+        }
         if (username == null || username.isEmpty()) {
             return Collections.emptyList();
         }
@@ -52,8 +60,8 @@ public class SupportTokenQueryExtension {
                 final List<GqlSupportTokenInfo> result = new ArrayList<>();
                 if (user.hasNode(SupportTokenConstants.NODE_NAME_TOKEN_HISTORY)) {
                     final JCRNodeIteratorWrapper iter = user.getNode(SupportTokenConstants.NODE_NAME_TOKEN_HISTORY).getNodes();
-                    for (Iterator<JCRNodeWrapper> it = iter.iterator(); iter.hasNext(); ) {
-                        final JCRNodeWrapper node = it.next();
+                    while (iter.hasNext()) {
+                        final JCRNodeWrapper node = (JCRNodeWrapper) iter.next();
                         final String createdDate = node.getPropertyAsString(Constants.JCR_CREATED);
                         final String recipient = node.getPropertyAsString(SupportTokenConstants.PROP_RECIPIENT);
                         final String description = node.getPropertyAsString(SupportTokenConstants.PROP_DESCRIPTION);
@@ -114,5 +122,19 @@ public class SupportTokenQueryExtension {
         public String getDescription() {
             return description;
         }
+    }
+
+    /**
+     * Returns {@code true} when the caller's HTTP session was established by the support-token
+     * auth valve.  Token-authenticated sessions must not be allowed to read token metadata
+     * (information disclosure prevention).
+     */
+    private static boolean isTokenAuthenticatedSession(DataFetchingEnvironment environment) {
+        final HttpServletRequest request = ContextUtil.getHttpServletRequest(environment.getContext());
+        if (request == null) {
+            return false;
+        }
+        final HttpSession session = request.getSession(false);
+        return session != null && Boolean.TRUE.equals(session.getAttribute(SupportTokenConstants.SESSION_SUPPORT_TOKEN_AUTH));
     }
 }

--- a/src/main/java/org/jahia/community/token/valve/SupportTokenAuthenticationValve.java
+++ b/src/main/java/org/jahia/community/token/valve/SupportTokenAuthenticationValve.java
@@ -153,6 +153,9 @@ public final class SupportTokenAuthenticationValve extends BaseAuthValve {
         if (SettingsBean.getInstance().isConsiderPreferredLanguageAfterLogin()) {
             request.getSession().setAttribute(Constants.SESSION_LOCALE, preferredLocale);
         }
+        // Mark this session as established by a support token so that
+        // token-management operations can refuse service to token-authed callers.
+        request.getSession().setAttribute(SupportTokenConstants.SESSION_SUPPORT_TOKEN_AUTH, Boolean.TRUE);
     }
     
     private void publishLoginEvents(JahiaUser jahiaUser, AuthValveContext authContext) {

--- a/src/main/resources/META-INF/definitions.cnd
+++ b/src/main/resources/META-INF/definitions.cnd
@@ -1,13 +1,13 @@
 <jnt = 'http://www.jahia.org/jahia/nt/1.0'>
 <jmix = 'http://www.jahia.org/jahia/mix/1.0'>
 
-[jnt:supportToken] > nt:base, jmix:nodenameInfo, jmix:unversionedBasemetadata, jmix:publication, jmix:observable, jmix:autoPublish
+[jnt:supportToken] > nt:base, jmix:nodenameInfo, jmix:unversionedBasemetadata, jmix:observable
  - token (string) indexed=no
  - expiration (long) indexed=no
  - description (string) indexed=no
  - recipient (string) indexed=no
 
-[jnt:supportTokenHistory] > nt:base, jmix:nodenameInfo, jmix:unversionedBasemetadata, jmix:publication, jmix:observable, jmix:autoPublish
+[jnt:supportTokenHistory] > nt:base, jmix:nodenameInfo, jmix:unversionedBasemetadata, jmix:observable
 + *(jnt:supportToken)
 
 [jmix:supportTokenUser] mixin


### PR DESCRIPTION
## Summary

Remediation from a support code review covering architecture, security, code quality, and documentation.

## Changes (4 commit(s))

- fix(security): set SESSION_SUPPORT_TOKEN_AUTH on token auth and block GraphQL token ops
- fix(email): correct expiration date in audit notification email
- fix(cnd): remove jmix:publication and jmix:autoPublish from token node types
- fix(command): correct misleading warning message in ListCommand

## Test plan

- `mvn clean install` succeeds
- Cypress E2E suite executed against Jahia EE 8.2 — passing.
