### PR TITLE
feat: add module-specific supportTokenAdmin permission for fine-grained RBAC

### DIFF
--- a/src/main/import/permissions.xml
+++ b/src/main/import/permissions.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<permissions xmlns:jcr="http://www.jcp.org/jcr/1.0">
+    <admin jcr:primaryType="jnt:permission">
+        <supportTokenAdmin jcr:primaryType="jnt:permission"/>
+    </admin>
+</permissions>

--- a/src/main/java/org/jahia/community/token/graphql/SupportTokenMutationExtension.java
+++ b/src/main/java/org/jahia/community/token/graphql/SupportTokenMutationExtension.java
@@ -31,7 +31,7 @@ public class SupportTokenMutationExtension {
     @GraphQLField
     @GraphQLName("supportTokenCreate")
     @GraphQLDescription("Creates a temporary support token for a user. Returns the generated token string, or null on failure.")
-    @GraphQLRequiresPermission("admin")
+    @GraphQLRequiresPermission("supportTokenAdmin")
     public static String createToken(
             @GraphQLName("username") @GraphQLDescription("Username to create the token for") String username,
             @GraphQLName("siteKey") @GraphQLDescription("Site key (null for global users)") String siteKey,
@@ -68,7 +68,7 @@ public class SupportTokenMutationExtension {
     @GraphQLField
     @GraphQLName("supportTokenClearAll")
     @GraphQLDescription("Removes all support tokens for a user")
-    @GraphQLRequiresPermission("admin")
+    @GraphQLRequiresPermission("supportTokenAdmin")
     public static Boolean clearAllTokens(
             @GraphQLName("username") @GraphQLDescription("Username whose tokens should be cleared") String username,
             @GraphQLName("siteKey") @GraphQLDescription("Site key (null for global users)") String siteKey,

--- a/src/main/java/org/jahia/community/token/graphql/SupportTokenQueryExtension.java
+++ b/src/main/java/org/jahia/community/token/graphql/SupportTokenQueryExtension.java
@@ -38,7 +38,7 @@ public class SupportTokenQueryExtension {
     @GraphQLField
     @GraphQLName("supportTokenListTokens")
     @GraphQLDescription("Lists the active tokens for a user")
-    @GraphQLRequiresPermission("admin")
+    @GraphQLRequiresPermission("supportTokenAdmin")
     public static List<GqlSupportTokenInfo> listTokens(
             @GraphQLName("username") @GraphQLDescription("Username to query") String username,
             @GraphQLName("siteKey") @GraphQLDescription("Site key (null for global users)") String siteKey,


### PR DESCRIPTION
## Summary

- Adds `src/main/import/permissions.xml` defining `supportTokenAdmin` as a child of `admin` in JCR, so Jahia packages it into `import.zip` at build time
- Updates all three `@GraphQLRequiresPermission("admin")` annotations in `SupportTokenMutationExtension` and `SupportTokenQueryExtension` to use the new `"supportTokenAdmin"` permission
- Full admins are unaffected — JCR privilege inheritance means holding `admin` implicitly satisfies `supportTokenAdmin`; non-admins can now be granted only `supportTokenAdmin` for least-privilege access

## Files changed

| File | Change |
|------|--------|
| `src/main/import/permissions.xml` | **New** — declares `supportTokenAdmin` child permission under `admin` |
| `src/main/java/.../graphql/SupportTokenMutationExtension.java` | Updated 2 annotations: `"admin"` → `"supportTokenAdmin"` |
| `src/main/java/.../graphql/SupportTokenQueryExtension.java` | Updated 1 annotation: `"admin"` → `"supportTokenAdmin"` |

## Test plan

- [ ] `mvn -q clean install` passes (verified locally — build green, `import.zip` includes `permissions.xml`)
- [ ] Deploy module on a Jahia instance and confirm `supportTokenAdmin` appears under `admin` in the JCR permissions tree (`/permissions/admin/supportTokenAdmin`)
- [ ] Verify a user with full `admin` can still call all three GraphQL operations
- [ ] Verify a user granted only `supportTokenAdmin` (not full `admin`) can call `supportTokenListTokens`, `supportTokenCreate`, and `supportTokenClearAll`
- [ ] Verify a user with neither permission is rejected by the GraphQL security layer