### PR TITLE
test: add fine-grained permission regression tests + assignable admin role

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.jahia.community</groupId>
     <artifactId>support-token-authentication-valve</artifactId>
     <name>Support Token Authentication Valve</name>
-    <version>3.1.0-SNAPSHOT</version>
+    <version>3.1.1-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <description>Jahia module that manages temporary support tokens for user authentication.</description>
 

--- a/src/javascript/SupportToken/register.jsx
+++ b/src/javascript/SupportToken/register.jsx
@@ -6,7 +6,7 @@ export default () => {
     console.debug('%c support-token-authentication-valve: activation in progress', 'color: #006633');
     registry.add('adminRoute', 'supportTokenAdmin', {
         targets: ['administration-server-usersAndRoles:10'],
-        requiredPermission: 'adminUsers',
+        requiredPermission: 'supportTokenAdmin',
         label: 'support-token-authentication-valve:label.menu_entry',
         isSelectable: true,
         render: () => React.createElement(SupportTokenAdmin)

--- a/src/main/import/roles.xml
+++ b/src/main/import/roles.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<roles jcr:primaryType="jnt:roles"
+       xmlns:jcr="http://www.jcp.org/jcr/1.0"
+       xmlns:j="http://www.jahia.org/jahia/1.0"
+       xmlns:jnt="http://www.jahia.org/jahia/nt/1.0">
+
+    <support-token-authentication-valve-administrator jcr:primaryType="jnt:role"
+                                                       j:nodeTypes="rep:root"
+                                                       j:roleGroup="server-role"
+                                                       j:permissionNames="administrationAccess supportTokenAdmin"
+                                                       j:privilegedAccess="true">
+        <j:translation_en jcr:primaryType="jnt:translation"
+                          jcr:language="en"
+                          jcr:title="Support Token administrator"
+                          jcr:description="Grants access to the Support Token administration without requiring full server administrator rights"/>
+    </support-token-authentication-valve-administrator>
+</roles>

--- a/tests/cypress/e2e/03-supportToken-Permissions.cy.ts
+++ b/tests/cypress/e2e/03-supportToken-Permissions.cy.ts
@@ -1,0 +1,83 @@
+import {DocumentNode} from 'graphql';
+import {createUser, deleteUser, grantRoles} from '@jahia/cypress';
+
+/**
+ * Regression tests for the fine-grained `supportTokenAdmin` permission.
+ *
+ * These guard against the gate being silently removed or mismatched across the stack:
+ *  - Backend: `@GraphQLRequiresPermission("supportTokenAdmin")` on the top-level
+ *    `supportTokenListTokens` query is enforced as `session.getNode("/").hasPermission("supportTokenAdmin")`.
+ *  - Frontend: `requiredPermission: 'supportTokenAdmin'` in register.jsx gates the server admin route.
+ *  - RBAC content: the module ships the assignable `support-token-authentication-valve-administrator`
+ *    role (src/main/import/roles.xml) granting only `administrationAccess` + `supportTokenAdmin`.
+ *
+ * The "allowed" user is granted that role and nothing else — never `admin` — so the tests prove
+ * fine-grained granularity, not merely that a full administrator can pass.
+ */
+describe('Support Token — permission enforcement', () => {
+    const ROLE_NAME = 'support-token-authentication-valve-administrator';
+    const DENIED_USER = 'stDeniedUser';
+    const ALLOWED_USER = 'stAllowedUser';
+    const PASSWORD = 'StPerm9PwdTest';
+    const ADMIN_PATH = '/jahia/administration/supportTokenAdmin';
+
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const listTokens: DocumentNode = require('graphql-tag/loader!../fixtures/graphql/query/listTokens.graphql');
+
+    const errorsOf = (result: {graphQLErrors?: Array<{message: string}>; errors?: Array<{message: string}>}) =>
+        result.graphQLErrors ?? result.errors ?? [];
+
+    const listTokensAs = (username: string) => {
+        cy.apolloClient({username, password: PASSWORD});
+        // root always exists and has no support tokens — a safe, read-only gated query.
+        return cy.apollo({query: listTokens, variables: {username: 'root', siteKey: null}});
+    };
+
+    before(() => {
+        cy.login();
+        createUser(DENIED_USER, PASSWORD);
+        createUser(ALLOWED_USER, PASSWORD);
+        // The annotation resolves the permission on the JCR root node, so grant the
+        // module-shipped single-permission role on `/`.
+        grantRoles('/', [ROLE_NAME], ALLOWED_USER, 'USER');
+    });
+
+    after(() => {
+        cy.apolloClient(); // reset the current Apollo client back to root
+        cy.login();
+        deleteUser(DENIED_USER);
+        deleteUser(ALLOWED_USER);
+    });
+
+    describe('GraphQL API authorization', () => {
+        it('denies the gated query for a user without the permission', () => {
+            listTokensAs(DENIED_USER).then((result: never) => {
+                const errs = errorsOf(result);
+                expect(errs, 'denial errors').to.have.length.greaterThan(0);
+                expect(errs.map((e: {message: string}) => e.message).join(' ')).to.contain('Permission denied');
+            });
+        });
+
+        it('allows the gated query for a user granted only the module permission', () => {
+            listTokensAs(ALLOWED_USER).then((result: never) => {
+                expect(errorsOf(result), 'should have no errors').to.have.length(0);
+                // root exists and has no support tokens → an empty list is returned (not null).
+                expect((result as {data: {supportTokenListTokens: unknown[]}}).data.supportTokenListTokens).to.be.an('array');
+            });
+        });
+    });
+
+    describe('Admin UI authorization', () => {
+        it('hides the admin panel from a user without the permission', () => {
+            cy.login(DENIED_USER, PASSWORD);
+            cy.visit(ADMIN_PATH, {failOnStatusCode: false});
+            cy.get('[class*="st_container"]').should('not.exist');
+        });
+
+        it('shows the admin panel to a user granted only the module permission', () => {
+            cy.login(ALLOWED_USER, PASSWORD);
+            cy.visit(ADMIN_PATH);
+            cy.get('[class*="st_container"]').should('be.visible');
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Adds regression coverage for the fine-grained `supportTokenAdmin` permission across the full stack and ships an assignable server-level admin role so the permission can be granted without full server-administrator rights.

- **`src/main/import/roles.xml`** (new): ships the `support-token-authentication-valve-administrator` role granting only `administrationAccess supportTokenAdmin` (server-role, privileged access).
- **`register.jsx`** (fix): the server admin route declared `requiredPermission: 'adminUsers'` — which meant the fine-grained role could never gate the admin UI. Changed to `supportTokenAdmin` to match the backend annotation and the shipped role. The per-site route keeps `siteAdminUsers` (separate, per-site concern — left untouched).
- **`tests/cypress/e2e/03-supportToken-Permissions.cy.ts`** (new): 4 tests. The 'allowed' user is granted ONLY the role (never `admin`), proving fine-grained granularity:
  - GraphQL: `supportTokenListTokens` is denied for an unprivileged user (Permission denied) and allowed (read-only, no token created/leaked) for the role-granted user.
  - Admin UI: the panel (`st_container`) is hidden for the unprivileged user and visible for the role-granted user.
- **`pom.xml`**: version bump `3.1.0-SNAPSHOT` → `3.1.1-SNAPSHOT` (roles.xml import content requires a version bump to re-import).

Notes:
- The gated GraphQL op is **top-level** (`@GraphQLTypeExtension(DXGraphQLProvider.Query.class)`), so the role only needs `supportTokenAdmin` (no GraphQL admin-traversal perms).
- No inner hardcoded server-level `admin` check exists in the resolver — it relies solely on `@GraphQLRequiresPermission("supportTokenAdmin")` — so no Java relaxation was needed.

## Test plan
- `mvn clean install` (verified roles.xml embedded in the jar's import.zip).
- `./ci.build.sh && ./ci.startup.sh` → **32/32 specs pass** (01-supportTokenAPI: 14, 02-supportTokenUI: 14, 03-supportToken-Permissions: 4). No regressions.
- License health clean (0 license errors in Jahia logs).